### PR TITLE
Fix reading time bug

### DIFF
--- a/server/fileProcessor.ts
+++ b/server/fileProcessor.ts
@@ -106,6 +106,10 @@ export function getFileExtension(filename: string): string {
 
 export function estimateReadingTime(text: string): number {
   const wordsPerMinute = 200;
-  const wordCount = text.split(/\s+/).length;
+  const cleaned = text.trim();
+  if (cleaned === "") {
+    return 0;
+  }
+  const wordCount = cleaned.split(/\s+/).length;
   return Math.ceil(wordCount / wordsPerMinute);
 }


### PR DESCRIPTION
## Summary
- fix `estimateReadingTime` to return 0 for blank strings

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2b420c4832e8bdaed7ad7b5f8ef